### PR TITLE
SDK初期化時のサンプルコード修正

### DIFF
--- a/app/src/main/java/mbaas/com/nifty/ncmbpushquickstart/MainActivity.java
+++ b/app/src/main/java/mbaas/com/nifty/ncmbpushquickstart/MainActivity.java
@@ -21,7 +21,7 @@ public class MainActivity extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         //**************** APIキーの設定とSDKの初期化 **********************
-        NCMB.initialize(this, "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
+        NCMB.initialize(this.getApplicationContext(), "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
 
         final NCMBInstallation installation = NCMBInstallation.getCurrentInstallation();
 


### PR DESCRIPTION
下記のinitializeメソッド内のthisを
NCMB.initialize(this,"YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
⇒ NCMB.initialize(this.getApplicationContext(), "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
に変更